### PR TITLE
Add support for custom extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # snowpack-plugin-replace
-replace your code
+Replace in your code.
 
 
 ## Usage
@@ -12,7 +12,7 @@ npm install --save-dev snowpack-plugin-replace
 
 ### Config
 
-add this plugin to your Snowpack config:
+Add this plugin to your Snowpack config:
 
 **snowpack.config.js**
 ```javascript
@@ -31,8 +31,10 @@ add this plugin to your Snowpack config:
 }
 ```
 
-options:
+Options:
 - from: `string` or `RegExp`
 - to: `string`
-- file: `string` **optional** specify file path. its should be a full path
+- file: `string` **optional** Specify file path. It should be a full path.
   > For Example: `require.resolve('./index.js')`
+- extensions: `string[]` **optional** Specify a list of extensions to limit which files should be replaced in.
+  - Defaults to `['.css', '.js', '.jsx', '.ts', '.tsx']`

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Add this plugin to your Snowpack config:
 }
 ```
 
-Options:
-- from: `string` or `RegExp`
-- to: `string`
-- file: `string` **optional** Specify file path. It should be a full path.
-  > For Example: `require.resolve('./index.js')`
+#### Options
 - extensions: `string[]` **optional** Specify a list of extensions to limit which files should be replaced in.
   - Defaults to `['.css', '.js', '.jsx', '.ts', '.tsx']`
+- list: List of replace-objects that can each have the following properties
+  - from: `string` or `RegExp`
+  - to: `string`
+  - file: `string` **optional** Specify file path. It should be a full path.
+    > For Example: `require.resolve('./index.js')`
+

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 const pkg = require('./package.json');
 
-const supportExt = ['.js', '.css']
-
 module.exports = function (snowpackConfig, pluginOptions) {
+  const exts = pluginOptions.extensions || ['.css', '.js', '.jsx', '.ts', '.tsx'];
+
   return {
     name: pkg.name,
     transform({ id, contents, fileExt }) {
-      if(!supportExt.includes(fileExt)) {
+      if (!exts.includes(fileExt)) {
         // Skip not support version
         return contents;
       }
@@ -14,7 +14,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
       const list = pluginOptions.list || [];
       for (let item of list) {
         const file = item.file;
-        if(typeof file === 'string') {
+        if (typeof file === 'string') {
           // If specify file path. check it
           if(file !== id) {
             continue;
@@ -22,7 +22,7 @@ module.exports = function (snowpackConfig, pluginOptions) {
         }
 
         let str = item.from;
-        if(str === undefined || str === null) {
+        if (str === undefined || str === null) {
           continue;
         }
 


### PR DESCRIPTION
Adds a new option `extensions` that allows the user to specify their own list of extensions that a replace can happen in. It defaults to a slightly expanded version of the old list of extensions. Open to feedback on that!